### PR TITLE
build as no noarch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
 
 outputs:
@@ -38,8 +38,6 @@ outputs:
         - importlib_resources
 
   - name: importlib-resources
-    build:
-      noarch: python
     requirements:
       host: 
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<38]
 
 outputs:
@@ -38,12 +38,14 @@ outputs:
         - importlib_resources
 
   - name: importlib-resources
+    build:
+      noarch: python
     requirements:
       host: 
         - python
       run:
         - python
-        - {{ pin_subpackage("importlib_resources", max_pin="x.x.x", exact=True) }}
+        - {{ pin_subpackage("importlib_resources", max_pin="x.x.x") }}
     test:
       requires:
         - pip


### PR DESCRIPTION
building as a no noarch as noarch has a problem to build with splink anything except py 3.11 version

