### PR TITLE
bump up build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
 
 outputs:


### PR DESCRIPTION
continuation of https://github.com/AnacondaRecipes/importlib_resources-feedstock/pull/3

- bump up build number
